### PR TITLE
Anch

### DIFF
--- a/components/ListEntry.js
+++ b/components/ListEntry.js
@@ -47,7 +47,7 @@ const ListEntry = (props) => {
   />)
 
   return(
-    <React.Fragment className="w-full">
+    <div className="w-full">
       {theseSections.length > 1 ? (
         <div className="w-full">
           <ListItemButton 
@@ -90,7 +90,7 @@ const ListEntry = (props) => {
           { coolSections }
         </div>
       )}
-    </React.Fragment>
+    </div>
   )
 }
 

--- a/components/NewSchedule.js
+++ b/components/NewSchedule.js
@@ -17,13 +17,16 @@ import ListItemIcon from "@mui/material/ListItemIcon";
 import ListItemText from "@mui/material/ListItemText";
 import Typography from "@mui/material/Typography";
 import IconButton from "@mui/material/IconButton";
+import Tooltip from "@mui/material/Tooltip";
 
 import { useSelector, useDispatch } from "react-redux";
 import {
   selectCourses,
   removeCourse,
+  updateSection,
   shiftCourseUp,
 } from "../src/features/userCourses/userCoursesSlice";
+import { courseAliasesIcons } from '/updateCourses/utils'
 
 const handleHour = (hour) => {
   if (hour == 0) {
@@ -83,6 +86,8 @@ const NewSchedule = (props) => {
                       id: course.objectID,
                       start,
                       end,
+                      sectionType,
+                      section: sectionId,
                       courseSubjNumb: `${section.Subj} ${section.Number}`,
                       courseTitle: section.Title,
                       color: course.color,
@@ -139,6 +144,8 @@ const NewSchedule = (props) => {
     const description = "coming soon!";
     return {
       Subject: interval.courseSubjNumb,
+      SectionType: interval.sectionType,
+      Section: interval.section,
       objectID: interval.id,
       FullName: interval.courseTitle,
       StartTime: new Date(
@@ -245,6 +252,10 @@ const NewSchedule = (props) => {
 
   const headerTemplate = (props) => {
     const c = pickTextColor(props.CategoryColor, "#fff", "#000");
+    const course = courses[courses.findIndex(course => course.objectID === props.objectID)];
+    const sectionTypeName = courseAliasesIcons[props.SectionType].type;
+    const multiNonLecture = Object.keys(course.sections[props.SectionType]).length == 1
+    console.log(props)
     return (
       <div className="px-5 py-3 flex flex-row">
         <div className="w-full">
@@ -252,17 +263,24 @@ const NewSchedule = (props) => {
             <Typography variant="h6" sx={{ color: c, fontWeight: "bold" }}>
               {props.Subject}
             </Typography>
-            <IconButton
-              aria-label="delete"
-              onClick={() => {
-                dispatch(removeCourse(props.objectID));
-              }}
-            >
-              <Delete fontSize="small" />
-            </IconButton>
+            <Tooltip title={multiNonLecture ? "Delete this course from your schedule" : `Delete this ${sectionTypeName} from your schedule`}>
+              <IconButton
+                aria-label="delete"
+                onClick={() => {
+                  if (multiNonLecture) {
+                    dispatch(removeCourse(props.objectID));
+                  } else {
+                    dispatch(updateSection({courseId: props.objectID, sectionType: props.SectionType, section: ""}));
+                  }
+                  eventRef.current.closeQuickInfoPopup();
+                }}
+              >
+                <Delete fontSize="small" sx={{ color: c }}/>
+              </IconButton>
+            </Tooltip>
           </div>
           <Typography variant="subtitle1" sx={{ color: c }}>
-            {props.FullName}
+            {props.FullName}&nbsp;—&nbsp;{sectionTypeName} {/* &nbsp;({props.Section}) */}
           </Typography>
         </div>
       </div>
@@ -283,6 +301,8 @@ const NewSchedule = (props) => {
           dataSource: data,
           fields: {
             subject: { name: "Subject" },
+            section: { name: "Section" },
+            sectionType: { name: "SectionType" },
             fullName: { name: "FullName" },
             isAllDay: { name: "IsAllDay" },
             startTime: { name: "StartTime" },

--- a/components/NewSchedule.js
+++ b/components/NewSchedule.js
@@ -254,7 +254,7 @@ const NewSchedule = (props) => {
             </Typography>
             <IconButton
               aria-label="delete"
-              onClick={(e) => {
+              onClick={() => {
                 dispatch(removeCourse(props.objectID));
               }}
             >

--- a/components/NewSchedule.js
+++ b/components/NewSchedule.js
@@ -1,138 +1,195 @@
-import React from 'react';
+import React from "react";
 
-import { ScheduleComponent, WorkWeek, Inject, ViewsDirective, ViewDirective } from '@syncfusion/ej2-react-schedule';
-import { Button } from '@mui/material';
-import { Room, Person, Schedule, Delete, Edit } from '@mui/icons-material';
+import {
+  ScheduleComponent,
+  WorkWeek,
+  Inject,
+  ViewsDirective,
+  ViewDirective,
+} from "@syncfusion/ej2-react-schedule";
+import { Button } from "@mui/material";
+import { Room, Person, Schedule, Delete, Edit } from "@mui/icons-material";
 
-import List from '@mui/material/List';
-import ListItem from '@mui/material/ListItem';
-import ListItemButton from '@mui/material/ListItemButton';
-import ListItemIcon from '@mui/material/ListItemIcon';
-import ListItemText from '@mui/material/ListItemText';
-import Typography from '@mui/material/Typography';
-import IconButton from '@mui/material/IconButton';
+import List from "@mui/material/List";
+import ListItem from "@mui/material/ListItem";
+import ListItemButton from "@mui/material/ListItemButton";
+import ListItemIcon from "@mui/material/ListItemIcon";
+import ListItemText from "@mui/material/ListItemText";
+import Typography from "@mui/material/Typography";
+import IconButton from "@mui/material/IconButton";
 
 import { useSelector, useDispatch } from "react-redux";
-import { selectCourses, deleteCourse } from '../src/features/userCourses/userCoursesSlice';
+import {
+  selectCourses,
+  removeCourse,
+  shiftCourseUp,
+} from "../src/features/userCourses/userCoursesSlice";
 
 const handleHour = (hour) => {
   if (hour == 0) {
-    return {"hour": 12, "suffix": "a.m."};
+    return { hour: 12, suffix: "a.m." };
   } else if (hour > 12) {
-    return {"hour": hour - 12, "suffix": "p.m."};
+    return { hour: hour - 12, suffix: "p.m." };
   } else if (hour == 12) {
-    return {"hour": hour, "suffix": "p.m."};
+    return { hour: hour, suffix: "p.m." };
   } else {
-    return {"hour": hour - 0, "suffix": "a.m."};
+    return { hour: hour - 0, suffix: "a.m." };
   }
-}
+};
 
 const pickTextColor = (bgColor, lightColor, darkColor) => {
-  var color = (bgColor.charAt(0) === '#') ? bgColor.substring(1, 7) : bgColor;
+  var color = bgColor.charAt(0) === "#" ? bgColor.substring(1, 7) : bgColor;
   var r = parseInt(color.substring(0, 2), 16); // hexToR
   var g = parseInt(color.substring(2, 4), 16); // hexToG
   var b = parseInt(color.substring(4, 6), 16); // hexToB
-  return (((r * 0.299) + (g * 0.587) + (b * 0.114)) > 186) ?
-    darkColor : lightColor;
-}
+  return r * 0.299 + g * 0.587 + b * 0.114 > 186 ? darkColor : lightColor;
+};
 
 const NewSchedule = (props) => {
-
   const dispatch = useDispatch();
 
-  const courses = useSelector(selectCourses); 
-  const intervals = courses.map(course => {
-    return Object.keys(course.sections).map(sectionType => {
-      return Object.keys(course.sections[sectionType]).filter(sectionId => {
-        return course.activeSections[sectionType] == course.sections[sectionType][sectionId].Section
-      }).map(sectionId => {
-        const section = course.sections[sectionType][sectionId];
-        return section.Meetings.map(meeting => {
-          return Object.keys(meeting).filter(day => {
-            return ((meeting[day] == "Y"))
-          }).map(day => {
-            const start = {
-              ...handleHour(meeting.Start.slice(0,2)),
-              minute: meeting.Start.slice(2,),
-              hour24: meeting.Start.slice(0,2),
-            }
-            const end = {
-              ...handleHour(meeting.End.slice(0,2)),
-              minute: meeting.End.slice(2,),
-              hour24: meeting.End.slice(0,2),
-            }
-            return { 
-              weekDay: day, 
-              start, 
-              end, 
-              courseSubjNumb: `${section.Subj} ${section.Number}`, 
-              courseTitle: section.Title,
-              color: course.color, 
-              startText: `${start.hour}:${start.minute} ${start.suffix}`, 
-              endText: `${end.hour}:${end.minute} ${end.suffix}`,
-              location: meeting.Location,
-              Crn: section?.Crn,
-              instructorString: section?.Instructors
-                ?.map(instructor => 
-                  instructor.Display.split(',').reverse().join(" "))
-                .join(', '),
-            }
-          })
-        }).flat();
-      }).flat();
-    }).flat();
-  }).flat();
+  const courses = useSelector(selectCourses);
+  const intervals = courses
+    .map((course) => {
+      return Object.keys(course.sections)
+        .map((sectionType) => {
+          return Object.keys(course.sections[sectionType])
+            .filter((sectionId) => {
+              return (
+                course.activeSections[sectionType] ==
+                course.sections[sectionType][sectionId].Section
+              );
+            })
+            .map((sectionId) => {
+              const section = course.sections[sectionType][sectionId];
+              return section.Meetings.map((meeting) => {
+                return Object.keys(meeting)
+                  .filter((day) => {
+                    return meeting[day] == "Y";
+                  })
+                  .map((day) => {
+                    const start = {
+                      ...handleHour(meeting.Start.slice(0, 2)),
+                      minute: meeting.Start.slice(2),
+                      hour24: meeting.Start.slice(0, 2),
+                    };
+                    const end = {
+                      ...handleHour(meeting.End.slice(0, 2)),
+                      minute: meeting.End.slice(2),
+                      hour24: meeting.End.slice(0, 2),
+                    };
+                    return {
+                      weekDay: day,
+                      id: course.objectID,
+                      start,
+                      end,
+                      courseSubjNumb: `${section.Subj} ${section.Number}`,
+                      courseTitle: section.Title,
+                      color: course.color,
+                      startText: `${start.hour}:${start.minute} ${start.suffix}`,
+                      endText: `${end.hour}:${end.minute} ${end.suffix}`,
+                      location: meeting.Location,
+                      Crn: section?.Crn,
+                      instructorString: section?.Instructors?.map(
+                        (instructor) =>
+                          instructor.Display.split(",").reverse().join(" ")
+                      ).join(", "),
+                    };
+                  });
+              }).flat();
+            })
+            .flat();
+        })
+        .flat();
+    })
+    .flat();
 
   const onEventRendered = React.useCallback((args) => {
     let categoryColor = args.data.CategoryColor;
-    if (!args.element || !categoryColor) { return; }
+    if (!args.element || !categoryColor) {
+      return;
+    }
     Object.assign(args.element.style, {
       backgroundColor: categoryColor,
     });
   }, []);
 
-  const data = intervals.map(interval => {
+  const data = intervals.map((interval) => {
     let weekDayNum;
     switch (interval.weekDay) {
-      case "M": weekDayNum = 1; break;
-      case "T": weekDayNum = 2; break;
-      case "W": weekDayNum = 3; break;
-      case "R": weekDayNum = 4; break;
-      case "F": weekDayNum = 5; break;
-      default:  weekDayNum = 6; break;
+      case "M":
+        weekDayNum = 1;
+        break;
+      case "T":
+        weekDayNum = 2;
+        break;
+      case "W":
+        weekDayNum = 3;
+        break;
+      case "R":
+        weekDayNum = 4;
+        break;
+      case "F":
+        weekDayNum = 5;
+        break;
+      default:
+        weekDayNum = 6;
+        break;
     }
     const description = "coming soon!";
     return {
       Subject: interval.courseSubjNumb,
+      objectID: interval.id,
       FullName: interval.courseTitle,
-      StartTime: new Date(2018, 0, weekDayNum, interval.start.hour24, interval.start.minute),
-      EndTime: new Date(2018, 0, weekDayNum, interval.end.hour24, interval.end.minute),
+      StartTime: new Date(
+        2018,
+        0,
+        weekDayNum,
+        interval.start.hour24,
+        interval.start.minute
+      ),
+      EndTime: new Date(
+        2018,
+        0,
+        weekDayNum,
+        interval.end.hour24,
+        interval.end.minute
+      ),
       IsAllDay: false,
       CategoryColor: interval.color.toString(),
       Description: description,
       Location: interval.location,
       Instructors: interval.instructorString,
-    }
-  })
+    };
+  });
 
   const eventRef = React.useRef();
 
   const bulletPoints = (props) => {
-    const [building, room] = props.Location ? props.Location.split(" ") : ["", ""];
-    const instructorList = props.Instructors.split(", ")
+    const [building, room] = props.Location
+      ? props.Location.split(" ")
+      : ["", ""];
+    const instructorList = props.Instructors.split(", ");
     const instructorLinks = instructorList.map((instructor, index) => {
-      let instructorPretty = instructor.split(" ")
-      if (instructorPretty.length > 3) { instructorPretty.splice(self.length - 2, 1) }
+      let instructorPretty = instructor.split(" ");
+      if (instructorPretty.length > 3) {
+        instructorPretty.splice(self.length - 2, 1);
+      }
       instructorPretty = instructorPretty.join("%20");
-      const end = index === instructorList.length - 1 ? " " : (<br />);
+      const end = index === instructorList.length - 1 ? " " : <br />;
       return (
-      <span key={index}><a 
-        href={`https://www.ratemyprofessors.com/search/teachers?query=${instructorPretty}&sid=U2Nob29sLTE0MA==`} 
-        target="_blank" 
-        rel="noopener noreferrer"
-      >{instructor}</a>{end}</span>
+        <span key={index}>
+          <a
+            href={`https://www.ratemyprofessors.com/search/teachers?query=${instructorPretty}&sid=U2Nob29sLTE0MA==`}
+            target="_blank"
+            rel="noopener noreferrer"
+          >
+            {instructor}
+          </a>
+          {end}
+        </span>
       );
-    })
+    });
 
     return (
       <List dense={true}>
@@ -140,121 +197,123 @@ const NewSchedule = (props) => {
           <ListItemIcon>
             <Schedule />
           </ListItemIcon>
-          <ListItemText 
-            primary={`${props.StartTime.toLocaleTimeString([], {hour: '2-digit', minute:'2-digit'})} - ${props.EndTime.toLocaleTimeString([], {hour: '2-digit', minute:'2-digit'})}`} 
-            // secondary={props.StartTime.toLocaleString()} 
+          <ListItemText
+            primary={`${props.StartTime.toLocaleTimeString([], {
+              hour: "2-digit",
+              minute: "2-digit",
+            })} - ${props.EndTime.toLocaleTimeString([], {
+              hour: "2-digit",
+              minute: "2-digit",
+            })}`}
+            // secondary={props.StartTime.toLocaleString()}
           />
         </ListItemButton>
-        {(building) && (
+        {building && (
           <ListItem>
             <ListItemIcon>
               <Room />
             </ListItemIcon>
-            <ListItemText 
-              primary={(<a 
-                href={`https://my.bucknell.edu/apps/m/building/${building}`} 
-                target="_blank" 
-                rel="noopener noreferrer">
+            <ListItemText
+              primary={
+                <a
+                  href={`https://my.bucknell.edu/apps/m/building/${building}`}
+                  target="_blank"
+                  rel="noopener noreferrer"
+                >
                   {building}&nbsp;{room}
-                </a>)} 
-              // secondary={room} 
+                </a>
+              }
+              // secondary={room}
             />
           </ListItem>
         )}
-        {(props.Instructors != []) && (<ListItem>
-          <ListItemIcon>
-            <Person />
-          </ListItemIcon>
-          <ListItemText primary={instructorLinks}/>
-        </ListItem>)}
+        {props.Instructors != [] && (
+          <ListItem>
+            <ListItemIcon>
+              <Person />
+            </ListItemIcon>
+            <ListItemText primary={instructorLinks} />
+          </ListItem>
+        )}
       </List>
-    )
-  }
+    );
+  };
 
   const contentTemplate = (props) => {
-    return (
-      bulletPoints(props)
-    )
-  }
+    return bulletPoints(props);
+  };
 
   const headerTemplate = (props) => {
-    // console.log(props)
     const c = pickTextColor(props.CategoryColor, "#fff", "#000");
-    return(
+    return (
       <div className="px-5 py-3 flex flex-row">
-        <div>
-          <Typography variant="h6" sx={{color: c, fontWeight: 'bold'}}>
-            {props.Subject}
-          </Typography>
-          <Typography variant="subtitle1" sx={{color: c}}>
+        <div className="w-full">
+          <div className="flex w-full justify-between">
+            <Typography variant="h6" sx={{ color: c, fontWeight: "bold" }}>
+              {props.Subject}
+            </Typography>
+            <IconButton
+              aria-label="delete"
+              onClick={(e) => {
+                dispatch(removeCourse(props.objectID));
+              }}
+            >
+              <Delete fontSize="small" />
+            </IconButton>
+          </div>
+          <Typography variant="subtitle1" sx={{ color: c }}>
             {props.FullName}
           </Typography>
         </div>
-        <div className="self-start content-end flex flex-row">
-          {/* <IconButton 
-            aria-label="info"
-            onClick={(e) => {
-
-            }}
-            disabled={true}
-          >
-            <Edit fontSize="small" />
-          </IconButton>
-          <IconButton 
-            aria-label="delete" 
-            disabled={true}
-            onClick={(e) => {
-              // dispatch(removeCourse(course.objectID))
-            }}
-          >
-            <Delete fontSize="small" />
-          </IconButton> */}
-        </div>
       </div>
-    )}
+    );
+  };
 
   return (
-    <ScheduleComponent 
-      className = "schedule"
-      readonly = {true}
-      timeScale={{ enable: true, interval: 60, slotCount: 2 }}
-      minDate = {new Date(2018, 0, 1)}
-      maxDate = {new Date(2018, 0, 5)}
-      selectedDate = {new Date(2018, 0, 1)}
-      eventRendered = {onEventRendered}
-      eventSettings = {{ 
-        dataSource: data,
-        fields: {
-          subject: { name: 'Subject' },
-          fullName: { name: 'FullName' },
-          isAllDay: { name: 'IsAllDay' },
-          startTime: { name: 'StartTime' },
-          endTime: { name: 'EndTime' },
-          categoryColor: { name: 'CategoryColor' },
-          description: { name: 'Description' },
-          location: { name: 'Location' },
-          instructors: { name: 'Instructors' },
-        }
-      }}
-      ref={eventRef}
-      quickInfoTemplates={{
-        header: headerTemplate,
-        content: contentTemplate
-      }}
-      onActionComplete = {(args) => {
-        if (args.requestType == 'dateNavigate') {
-          eventRef.current.scrollTo('08', new Date(2018, 0, 1));
-      }}}
-      onEventClick = {(args) => {
-        console.log(args)
-      }}
-    >
-      <ViewsDirective>
-        <ViewDirective option='WorkWeek' startHour='08:00' endHour='22:00'/>
-      </ViewsDirective>
-      <Inject services={[WorkWeek]}/>
-    </ScheduleComponent>
+    <div>
+      <ScheduleComponent
+        className="schedule"
+        readonly={true}
+        timeScale={{ enable: true, interval: 60, slotCount: 2 }}
+        minDate={new Date(2018, 0, 1)}
+        maxDate={new Date(2018, 0, 5)}
+        selectedDate={new Date(2018, 0, 1)}
+        eventRendered={onEventRendered}
+        eventSettings={{
+          dataSource: data,
+          fields: {
+            subject: { name: "Subject" },
+            fullName: { name: "FullName" },
+            isAllDay: { name: "IsAllDay" },
+            startTime: { name: "StartTime" },
+            endTime: { name: "EndTime" },
+            categoryColor: { name: "CategoryColor" },
+            description: { name: "Description" },
+            location: { name: "Location" },
+            instructors: { name: "Instructors" },
+          },
+        }}
+        ref={eventRef}
+        quickInfoTemplates={{
+          header: headerTemplate,
+          content: contentTemplate,
+        }}
+        onActionComplete={(args) => {
+          if (args.requestType == "dateNavigate") {
+            eventRef.current.scrollTo("08", new Date(2018, 0, 1));
+          }
+        }}
+        eventClick={(args) => {
+          dispatch(shiftCourseUp(args.event.objectID));
+        }}
+      >
+        <ViewsDirective>
+          <ViewDirective option="WorkWeek" startHour="08:00" endHour="22:00" />
+        </ViewsDirective>
+        <Inject services={[WorkWeek]} />
+      </ScheduleComponent>
+    </div>
   );
-}
+};
 
 export default NewSchedule;

--- a/src/features/userCourses/userCoursesSlice.js
+++ b/src/features/userCourses/userCoursesSlice.js
@@ -36,6 +36,16 @@ const userCoursesSlice = createSlice({
         removeCourse: (state, action) => {
             state.courses = [...state.courses.filter(course => course.objectID !== action.payload)]
         },
+        shiftCourseUp: (state, action) => {
+            let coursesCopy = [...state.courses]
+            let cID = coursesCopy.findIndex(c => c.objectID == action.payload)
+            if (cID == 0) {
+                return
+            }
+            let removed = coursesCopy.splice(cID, 1)
+            coursesCopy.unshift(removed[0])
+            state.courses = coursesCopy
+        },
         setSchedules: (state, action) => {
             state.schedules = action.payload
         },
@@ -59,6 +69,7 @@ export const {
     removeCourse,
     updateSection,
     setSchedules,
+    shiftCourseUp,
     unsetSchedules,
     addSchedule,
     unsetAll,


### PR DESCRIPTION
Ignore the overall formatting changes, I think that's because I use a new formatter (I use Prettier on VScode). 

Overall, the branch deals with issue #2 and adds a delete to #3. Clicking on a course on the schedule automatically pushes that course onto the top as needed, and there is a delete button on the popup. 

I was going to add the edit functionality but `expand` was local to the CourseCard, and I didn't really want to bloat the global store just to expand a section (which can be done easily given that the course now pops up to the top). 

Possible improvements:
- Extra Delete button doesn't delete the `quickinfopopup` instantly and the user is forced to click elsewhere to remove it. 
- Deleting a "recitation" / "lab" session just deletes the entire course, not the chosen active session. 

